### PR TITLE
Fixed WavTrackImpl to work for lazy loaded URLs

### DIFF
--- a/resources/mediaplayer/src/main/java/org/mobicents/media/server/impl/resource/mediaplayer/audio/wav/WavTrackImpl.java
+++ b/resources/mediaplayer/src/main/java/org/mobicents/media/server/impl/resource/mediaplayer/audio/wav/WavTrackImpl.java
@@ -112,7 +112,7 @@ public class WavTrackImpl implements Track {
             long offset = frameSize * (timestamp / period/ 1000000L);
             byte[] skip = new byte[(int)offset];
             int bytesRead=0;
-            while(bytesRead<skip.length && inStream.available()>0)
+            while(bytesRead<skip.length)
             {
             	int len=inStream.read(skip,bytesRead,skip.length-bytesRead);
             	if(len==-1)
@@ -132,7 +132,7 @@ public class WavTrackImpl implements Track {
     	byte[] headerEnd = null;
     	int tempValue;
     	int bytesRead=0;
-    	while (bytesRead < 36 && stream.available()>0) {
+    	while (bytesRead < 36) {
             int len = stream.read(header, bytesRead, 36 - bytesRead);
             if (len == -1) {                	
                 return;
@@ -179,7 +179,7 @@ public class WavTrackImpl implements Track {
     	headerEnd=new byte[8+ckSize-16];
 		bytesRead=0;   	
     	extraHeaderSize=headerEnd.length;
-    	while (bytesRead < extraHeaderSize && stream.available()>0) {
+    	while (bytesRead < extraHeaderSize) {
             int len = stream.read(headerEnd, bytesRead, extraHeaderSize - bytesRead);
             if (len == -1) {                	
                 return;
@@ -204,7 +204,7 @@ public class WavTrackImpl implements Track {
     		sizeOfData-=12;
     		headerEnd=new byte[12];
     		bytesRead=0;
-    		while (bytesRead < 12 && stream.available()>0) {
+    		while (bytesRead < 12) {
                 int len = stream.read(headerEnd, bytesRead, 12 - bytesRead);
                 if (len == -1) {                	
                     return;
@@ -233,7 +233,7 @@ public class WavTrackImpl implements Track {
     private int readPacket(byte[] packet, int offset, int psize) throws IOException {
         int length = 0;
         try {
-            while (length < psize && inStream.available()>0) {
+            while (length < psize) {
                 int len = inStream.read(packet, offset + length, psize - length);
                 if (len == -1) {
                 	return length;


### PR DESCRIPTION
Current implementation used incorrect check for available bytes in media URL input stream. This fixes that issue that cause to be unable to load resources form network (http/https) URLs.